### PR TITLE
Update X.Web.RSS dependency.

### DIFF
--- a/EclassApi.Tests/EclassApi.Tests.csproj
+++ b/EclassApi.Tests/EclassApi.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/EclassApi/EclassApi.csproj
+++ b/EclassApi/EclassApi.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.4;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.4' ">$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;dotnet</PackageTargetFallback>
     <ApplicationIcon />
     <StartupObject />  
@@ -27,6 +27,6 @@
   <ItemGroup>
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.12" />
-    <PackageReference Include="xwebrss" Version="2.2.0" />
+    <PackageReference Include="X.Web.RSS" Version="2.7.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi! 

I see that your project use **xwebrss** package.
I just moved it to the new location: https://nuget.org/packages/X.Web.RSS
So this PR contains actual package name. Also I updated project settings to the actual .NET version.

Regards, Andrey.